### PR TITLE
clean-up for PR#10 adding protocal to manifest

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,3 +26,8 @@ when using the authorization code flow or the device code flow, AzSessions will 
 the `client_id` and the `tenant` but will not use the `client_secret`.The later is
 especially useful if you are working in an environment where your adminstrator does not
 share the `client_secret` with the users.
+
+Note that the manifest can also be used to store your preferred protocal.  For example:
+```julia
+AzSessions.write_manifest(;client_id="myclientid", client_secret="mycientsecret", tenant="mytenant", protocal=AzClientCredentials)
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -403,3 +403,20 @@ end
     @test manifest["client_secret"] == "myclientsecret"
     @test manifest["tenant"] == "mytenant"
 end
+
+AzSessions.write_manifest(;client_id=credentials["clientId"], client_secret=credentials["clientSecret"], tenant=credentials["tenantId"], protocal="AzClientCredentials")
+@testset "AzSessions, Client Credentials is the default" begin
+    session = AzSession()
+    @test session.protocal == "AzClientCredentials"
+    @test now(Dates.UTC) < session.expiry
+    t = token(session)
+    @test isa(t,String)
+    t2 = token(session)
+    @test t2 == t
+
+    session.token = "x"
+    session.expiry = now(Dates.UTC) - Dates.Second(1)
+    t2 = token(session)
+    @test t2 != "x"
+end
+AzSessions.write_manifest(;client_id=credentials["clientId"], client_secret=credentials["clientSecret"], tenant=credentials["tenantId"], protocal="")


### PR DESCRIPTION
This is a small clean-up for PR#10.  This fixes a few things...

1. Update docs
2. Switch from "auth"->"protocal"
3. If a protocal is chosen in the manifest, and the user passes a protocal via a named argument to AzSession, then the named argument prtocal takes precident.
4. Fixes loading/writing session from/to a dict.

@mloubout 