### PR TITLE
fix login prompt for Jupyter Lab

### DIFF
--- a/src/AzSessions.jl
+++ b/src/AzSessions.jl
@@ -582,7 +582,10 @@ function token(session::AzDeviceCodeFlowSession, bootstrap=false)
     r = JSON.parse(String(_r.body))
 
     device_code = r["device_code"]
+
     @info r["message"]
+    flush(stdout)
+    flush(stderr)
 
     local _r
     while true


### PR DESCRIPTION
The login instructions were not being displayed in Jupyter Lab.  Flushing stdout/stderr before entering the response loop seems to fix it.